### PR TITLE
Fix missing openldap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN CONFARGS=$(nginx -V 2>&1 | sed -n -e 's/^.*arguments: //p') \
 
 FROM nginx:alpine
 # Extract the dynamic module NCHAN from the builder image
+RUN apk add --no-cache openldap
 COPY --from=builder /usr/lib/nginx/ngx_http_auth_ldap_module.so /usr/lib/nginx/ngx_http_auth_ldap_module.so
 COPY ngx_http_auth_ldap_module.nginx /etc/nginx/modules.d/
 


### PR DESCRIPTION
I got following error for the newly released image. The nginx module is missing a dependency to libdap, which I solved by installing openldap in the release image

```2019/05/11 09:19:36 [emerg] 1#1: dlopen() "/usr/lib/nginx/ngx_http_auth_ldap_module.so" failed
(Error loading shared library libldap-2.4.so.2: No such file or directory (needed by 
/usr/lib/nginx/ngx_http_auth_ldap_module.so)) in /etc/nginx/nginx.conf:7
nginx: [emerg] dlopen() "/usr/lib/nginx/ngx_http_auth_ldap_module.so" failed
(Error loading shared library libldap-2.4.so.2: No such file or directory (needed by 
/usr/lib/nginx/ngx_http_auth_ldap_module.so)) in /etc/nginx/nginx.conf:7```